### PR TITLE
Fix stop() ignoring timeout parameter

### DIFF
--- a/src/fastscheduler/main.py
+++ b/src/fastscheduler/main.py
@@ -383,7 +383,7 @@ class FastScheduler:
         self.running = False
 
         if wait and self.thread and self.thread.is_alive():
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=timeout)
 
         # Shutdown executors
         if wait:


### PR DESCRIPTION
**Summary**: The `stop()` method accepts a `timeout` parameter but ignored it, always using a hardcoded 5-second timeout for `thread.join()`.
**Fix**: Use the `timeout` parameter instead of hardcoded `5`.
**Test**: Added test `test_stop_timeout_parameter_passed_to_thread_join` to verify the timeout value is passed correctly.

Before Fix:
```bash
cosmo:fastscheduler (fix-stop-timeout-parameter *) | uv run pytest tests/test_scheduler.py::TestSchedulerLifecycle::test_stop_timeout_parameter_passed_to_thread_join -v
==================================================================================================== test session starts =====================================================================================================
platform linux -- Python 3.13.10, pytest-8.4.2, pluggy-1.5.0 -- /home/sam/workspace/contrib/fastscheduler/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/sam/workspace/contrib/fastscheduler
configfile: pytest.ini
plugins: anyio-4.5.2
collected 1 item

tests/test_scheduler.py::TestSchedulerLifecycle::test_stop_timeout_parameter_passed_to_thread_join FAILED                                                                                                              [100%]

========================================================================================================== FAILURES ==========================================================================================================
__________________________________________________________________________ TestSchedulerLifecycle.test_stop_timeout_parameter_passed_to_thread_join __________________________________________________________________________
tests/test_scheduler.py:454: in test_stop_timeout_parameter_passed_to_thread_join
    assert captured_timeout[0] == 3, (
E   AssertionError: stop(timeout=3) should pass 3 to thread.join(), but passed 5 instead
E   assert 5 == 3
================================================================================================== short test summary info ===================================================================================================
FAILED tests/test_scheduler.py::TestSchedulerLifecycle::test_stop_timeout_parameter_passed_to_thread_join - AssertionError: stop(timeout=3) should pass 3 to thread.join(), but passed 5 instead
assert 5 == 3
===================================================================================================== 1 failed in 0.36s ======================================================================================================

```


Post Fix:
```bash
cosmo:fastscheduler (main *) | uv run pytest tests/test_scheduler.py::TestSchedulerLifecycle::test_stop_timeout_parameter_passed_to_thread_join -v
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.13.10, pytest-8.4.2, pluggy-1.5.0 -- /home/sam/workspace/contrib/fastscheduler/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/sam/workspace/contrib/fastscheduler
configfile: pytest.ini
plugins: anyio-4.5.2
collected 1 item

tests/test_scheduler.py::TestSchedulerLifecycle::test_stop_timeout_parameter_passed_to_thread_join PASSED                                                                                                     [100%]

================================================================================================= 1 passed in 0.38s =================================================================================================
```