### PR TITLE
Make create_scheduler_routes more flexible

### DIFF
--- a/src/fastscheduler/fastapi_integration.py
+++ b/src/fastscheduler/fastapi_integration.py
@@ -119,7 +119,7 @@ def create_scheduler_routes(scheduler: "FastScheduler", **router_kwargs) -> APIR
         template = _load_dashboard_template()
 
         # Replace template variables
-        html = template.replace("{{prefix}}", prefix)
+        html = template.replace("{{prefix}}", router_kwargs['prefix'])
 
         return html
 


### PR DESCRIPTION
Allows to set and overwrite all attributes of FastAPI router

E.g. allows to overwrite tags and dependencies
```python
scheduler_router = create_scheduler_routes(scheduler, prefix="/tasks", tags=["tasks"], dependencies=[...])
```