### PR TITLE
stop SSE events if scheduler stop

### DIFF
--- a/src/fastscheduler/fastapi_integration.py
+++ b/src/fastscheduler/fastapi_integration.py
@@ -63,7 +63,7 @@ def create_scheduler_routes(scheduler: "FastScheduler", **router_kwargs) -> APIR
 
     async def event_generator() -> AsyncGenerator[str, None]:
         """Generate SSE events for real-time updates"""
-        while True:
+        while scheduler.running:
             try:
                 # Get current state
                 stats = scheduler.get_statistics()


### PR DESCRIPTION
Subject: Fix: Fastapi cannot shutdown when active SSE connections exist

Description: Currently, the FastAPI server fails to shut down if a background page (using SSE) is open.

FastAPI's default behavior is to wait for all active connections to close before finalizing the shutdown. However, the current execution order creates a deadlock:

Ctrl + C is triggered.

FastAPI waits for connections to close.

FastAPI executes the lifecycle "shutdown" event (where the scheduler is supposed to stop).

The issue is that the connection will never close as long as the scheduler is running (due to the infinite loop in the SSE endpoint).

Proposed Solution: We should intercept the signal to shut down the scheduler earlier in the process:

Ctrl + C is triggered.

Capture the signal and shut down the scheduler immediately.

Existing connections (SSE) terminate because the data source is closed.

FastAPI proceeds with its standard cleanup and exits successfully.

While this requires manual signal handling to stop the scheduler early, it provides a viable path to gracefully shut down the server.