### PR TITLE
Feature: store stack trace on failed jobs and display on dashboard

### DIFF
--- a/src/fastscheduler/main.py
+++ b/src/fastscheduler/main.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from pathlib import Path
+from traceback import format_exception
 from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Optional, Union
 from zoneinfo import ZoneInfo
 
@@ -255,6 +256,7 @@ class FastScheduler:
         func_name: str,
         status: JobStatus,
         error: Optional[str] = None,
+        traceback: Optional[str] = None,
         run_count: int = 0,
         retry_count: int = 0,
         execution_time: Optional[float] = None,
@@ -266,6 +268,7 @@ class FastScheduler:
             status=status.value,
             timestamp=time.time(),
             error=error,
+            traceback=traceback,
             run_count=run_count,
             retry_count=retry_count,
             execution_time=execution_time,
@@ -553,6 +556,7 @@ class FastScheduler:
                     job.func_name,
                     JobStatus.FAILED,
                     error=f"Retry {job.retry_count}/{job.max_retries}: {error_msg}",
+                    traceback="".join(format_exception(e)),
                     run_count=job.run_count,
                     retry_count=job.retry_count,
                     execution_time=execution_time,
@@ -569,6 +573,7 @@ class FastScheduler:
                     job.func_name,
                     JobStatus.FAILED,
                     error=f"Max retries exceeded: {error_msg}",
+                    traceback="".join(format_exception(e)),
                     run_count=job.run_count,
                     retry_count=job.retry_count,
                     execution_time=execution_time,

--- a/src/fastscheduler/models.py
+++ b/src/fastscheduler/models.py
@@ -101,6 +101,7 @@ class JobHistory:
     status: str
     timestamp: float
     error: Optional[str] = None
+    traceback: Optional[str] = None
     run_count: int = 0
     retry_count: int = 0
     execution_time: Optional[float] = None

--- a/src/fastscheduler/storage/models.py
+++ b/src/fastscheduler/storage/models.py
@@ -107,6 +107,7 @@ class JobHistoryModel(SQLModel, table=True):
     status: str
     timestamp: float = Field(index=True)
     error: Optional[str] = None
+    traceback: Optional[str] = None
     run_count: int = 0
     retry_count: int = 0
     execution_time: Optional[float] = None
@@ -120,6 +121,7 @@ class JobHistoryModel(SQLModel, table=True):
             "status": self.status,
             "timestamp": self.timestamp,
             "error": self.error,
+            "traceback": self.traceback,
             "run_count": self.run_count,
             "retry_count": self.retry_count,
             "execution_time": self.execution_time,
@@ -137,6 +139,7 @@ class JobHistoryModel(SQLModel, table=True):
             status=data["status"],
             timestamp=data["timestamp"],
             error=data.get("error"),
+            traceback=data.get("traceback"),
             run_count=data.get("run_count", 0),
             retry_count=data.get("retry_count", 0),
             execution_time=data.get("execution_time"),
@@ -154,6 +157,7 @@ class DeadLetterModel(SQLModel, table=True):
     status: str
     timestamp: float = Field(index=True)
     error: Optional[str] = None
+    traceback: Optional[str] = None
     run_count: int = 0
     retry_count: int = 0
     execution_time: Optional[float] = None
@@ -167,6 +171,7 @@ class DeadLetterModel(SQLModel, table=True):
             "status": self.status,
             "timestamp": self.timestamp,
             "error": self.error,
+            "traceback": self.traceback,
             "run_count": self.run_count,
             "retry_count": self.retry_count,
             "execution_time": self.execution_time,
@@ -184,6 +189,7 @@ class DeadLetterModel(SQLModel, table=True):
             status=data["status"],
             timestamp=data["timestamp"],
             error=data.get("error"),
+            traceback=data.get("traceback"),
             run_count=data.get("run_count", 0),
             retry_count=data.get("retry_count", 0),
             execution_time=data.get("execution_time"),

--- a/src/fastscheduler/templates/dashboard.html
+++ b/src/fastscheduler/templates/dashboard.html
@@ -564,6 +564,32 @@
             overflow-y: auto;
         }
 
+        /* Modal */
+        #outputModal {
+            top: 50%;
+            left: 50%;
+            width: 60vw;
+            position: absolute;
+            border-radius: 10px;
+            transform: translate(-50%, -50%);
+        }
+
+        #outputModal .modal-content {
+            padding: 28px;
+            gap: 16px;
+            display: flex;
+            flex-direction: column;
+        }
+
+        dialog {
+            color: inherit;
+        }
+
+        dialog::backdrop {
+            opacity: 0.5;
+            background-color: #898989;
+        }
+
         /* Empty state */
         .empty-state {
             padding: 48px;
@@ -774,6 +800,7 @@
                                 <th>Time</th>
                                 <th>Duration</th>
                                 <th>Details</th>
+                                <th>Output</th>
                             </tr>
                         </thead>
                         <tbody id="history-tbody"></tbody>
@@ -808,6 +835,7 @@
                                 <th>Run #</th>
                                 <th>Retries</th>
                                 <th>Duration</th>
+                                <th>Output</th>
                             </tr>
                         </thead>
                         <tbody id="failed-tbody"></tbody>
@@ -816,6 +844,18 @@
             </div>
         </div>
     </main>
+
+    <dialog id="outputModal">
+        <div class="section-box modal-content">
+            <div class="section-header">
+                <div class="section-title" id="outputModalTitle">Modal title</div>
+                <button class="action-btn" type="button" onclick="closeOutputModal()">Dismiss</button>
+            </div>
+            <div class="dead-letter-info">
+                <pre id="outputModalBody">Modal body.</pre>
+            </div>
+        </div>
+    </dialog>
 
     <div class="toast-container" id="toast-container"></div>
 
@@ -1057,9 +1097,14 @@
                     <td><span class="history-time">${h.timestamp_readable || formatTs(h.timestamp)}</span></td>
                     <td><span class="history-duration">${h.execution_time ? h.execution_time.toFixed(2) + 's' : '-'}</span></td>
                     <td>${h.error
-                    ? `<span class="history-error" title="${esc(h.error)}">${esc(h.error)}</span>`
-                    : `<span style="color:var(--text-tertiary)">Run #${h.run_count || '-'}</span>`
-                }</td>
+                        ? `<span class="history-error" title="${esc(h.error)}">${esc(h.error)}</span>`
+                        : `<span style="color:var(--text-tertiary)">Run #${h.run_count || '-'}</span>`
+                    }</td>
+                    <td>
+                        <div class="action-btns">
+                            <button class="action-btn" ${h.traceback ? '' : 'disabled'} onclick="showOutputModal('Stack Trace', '${encodeURIComponent(h.traceback)}')">Trace</button>
+                        </div>
+                    </td>
                 </tr>
             `).join('');
         }
@@ -1090,6 +1135,11 @@
                     <td><span style="color:var(--text-secondary)">#${dl.run_count || '-'}</span></td>
                     <td><span style="color:var(--text-secondary)">${dl.retry_count || 0}</span></td>
                     <td><span class="history-duration">${dl.execution_time ? dl.execution_time.toFixed(2) + 's' : '-'}</span></td>
+                    <td>
+                        <div class="action-btns">
+                            <button class="action-btn" ${dl.traceback ? '' : 'disabled'} onclick="showOutputModal('Stack Trace', '${encodeURIComponent(dl.traceback)}')">Trace</button>
+                        </div>
+                    </td>
                 </tr>
             `).join('');
         }
@@ -1138,6 +1188,22 @@
             const res = await fetch(`${API}/api/dead-letters`, { method: 'DELETE' });
             const d = await res.json();
             toast(d.success ? 'success' : 'error', d.success ? `Cleared ${d.cleared} entries` : 'Failed to clear');
+        }
+
+        // Modal
+        function showOutputModal(header, content) {
+            const dialog = document.getElementById('outputModal');
+            const title = document.getElementById('outputModalTitle');
+            const body = document.getElementById('outputModalBody');
+
+            title.textContent = header;
+            body.textContent = decodeURIComponent(content);
+            dialog.showModal();
+        }
+
+        function closeOutputModal() {
+            const dialog = document.getElementById('outputModal');
+            dialog.close();
         }
 
         // Toast

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -375,6 +375,28 @@ class TestStatistics:
         for entry in history:
             assert entry["func_name"] == "test_job"
 
+    def test_history_error_traceback(self, scheduler):
+        """Test job traceback logging on failure"""
+        attempts = []
+
+        @scheduler.every(0.1).seconds.retries(3)
+        def failing_job():
+            attempts.append(1)
+            if len(attempts) < 2:
+                raise ValueError("Intentional error")
+            return "success"
+
+        scheduler.start()
+        time.sleep(0.5)
+        scheduler.stop()
+
+        # Should have history with at least one error, with stack trace string
+        history = scheduler.get_history()
+        errors = [item for item in history if item["error"] is not None]
+        assert len(errors) > 0
+        assert "traceback" in errors[0]
+        assert 'raise ValueError("Intentional error")' in errors[0]["traceback"]
+
 
 class TestSchedulerLifecycle:
     """Test scheduler lifecycle management"""


### PR DESCRIPTION
This PR adds a string field to history models and stores the stack trace text on job exceptions.

On the dashboard, it adds a "Trace" button to each line on the history and failed tables. The button shows a modal dialog with the text of the stack trace. The button is disabled if there is no trace.

Please check my work, especially with respect to:
- HTML/CSS/JS in order to keep a consistent UI;
- more or better tests.

I plan to add the possibility to capture and store the output of each job (optional, default False). Similarly, it would be shown on the history and failed tables with an "STDOUT" button to the left of the "Trace" one. The button would be disabled if there was no capture. It seems that using `redirect_stdout` and `redirect_stderr` from `contextlib` would be the simplest solution. Comments are welcome.